### PR TITLE
feature: add date filtering to pedidos endpoint with query parameters

### DIFF
--- a/mofulunches-api/api_gateway/API_GATEWAY_ENDPOINTS.md
+++ b/mofulunches-api/api_gateway/API_GATEWAY_ENDPOINTS.md
@@ -511,7 +511,11 @@ For this endpoint, you can filter by date using query params, in this case using
 
 **Method**: `GET`
 
-**Description**: Get all pedidos list.
+**Description**: Get all pedidos list. You can filter by date using query params `desde` and `hasta`.
+
+**Query Parameters**:
+- `desde` (optional): Start date in YYYY-MM-DD format.
+- `hasta` (optional): End date in YYYY-MM-DD format.
 
 **Response**:
 

--- a/mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py
+++ b/mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py
@@ -30,7 +30,11 @@ def create_pedidos_blueprint():
     # Pedidos service routes
     @pedidos_bp.route('/pedidos', methods=['GET'])
     def get_pedidos():
-        return handle_request("pedidos", "GET")
+        params = {
+            "desde": request.args.get("desde"),
+            "hasta": request.args.get("hasta")
+        }
+        return handle_request("pedidos", "GET", params=params)
 
     @pedidos_bp.route('/pedidos/diarios', methods=['GET'])
     def get_pedidos_diarios():

--- a/mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md
+++ b/mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md
@@ -28,6 +28,10 @@ SECRET_KEY = "flask-secret-key"
 
 **Method**: `GET`
 
+**Query Parameters**:
+- `desde` (optional): Start date for filtering pedidos.
+- `hasta` (optional): End date for filtering pedidos.
+
 **Description**: Get full 'pedidos' list, with 
 
 **Response**:

--- a/mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py
+++ b/mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py
@@ -22,12 +22,26 @@ pedidos_collection = PedidosCollection().collection
 # Get pedidos full list
 @pedidos_bp.route('/pedidos', methods=['GET'])
 def get_pedidos():
-    pedidos = list(pedidos_collection.find({}))
-    
+    # Query params
+    fecha_inicio = request.args.get("desde")  # min date
+    fecha_fin = request.args.get("hasta")  # max date
+
+    # MongoDB filter
+    filtro = {}
+    if fecha_inicio or fecha_fin:
+        filtro["fecha_pedido"] = {}
+        if fecha_inicio:
+            filtro["fecha_pedido"]["$gte"] = fecha_inicio
+        if fecha_fin:
+            filtro["fecha_pedido"]["$lte"] = fecha_fin
+
+    # MongoDB query
+    pedidos = list(pedidos_collection.find(filtro))
+
     # Convert ObjectId to string
     for pedido in pedidos:
         pedido['_id'] = str(pedido['_id'])
-
+        
     return jsonify(pedidos), 200
 
 


### PR DESCRIPTION
This pull request introduces the ability to filter `pedidos` by date using query parameters in the `mofulunches-api`. The most important changes include updates to the API documentation, modifications to the request handling in the `pedidos` blueprint, and the addition of query parameters to filter the results from the MongoDB collection.

### API Documentation Updates:
* [`mofulunches-api/api_gateway/API_GATEWAY_ENDPOINTS.md`](diffhunk://#diff-3081c39a4b7027695caa81eb666ca8b8a321e5a763c3f83468f027046332db7aL514-R518): Updated the description to include the new query parameters `desde` and `hasta` for filtering by date. Added a new section for query parameters.
* [`mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md`](diffhunk://#diff-2b393b2b89d3b53f6d79485c779f59c801d95f4a8c1a2795d68b287ef2aa098aR31-R34): Added the `desde` and `hasta` query parameters for filtering the `pedidos` list.

### Request Handling Modifications:
* [`mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py`](diffhunk://#diff-6051904615a331fdaee002cf50f48249de351fb05a43b3b0401ded0bbba10d83L33-R37): Modified the `get_pedidos` function to include the `desde` and `hasta` query parameters in the request to the `handle_request` function.
* [`mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py`](diffhunk://#diff-6d5e1c345f7a0761473567b1560a7e07989108c7cc9ded0382b7c3ef5a95a27dL25-R39): Added logic to filter the `pedidos` collection based on the `desde` and `hasta` query parameters.