### PR TITLE
RUT Query params filter

### DIFF
--- a/mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py
+++ b/mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py
@@ -42,7 +42,11 @@ def create_pedidos_blueprint():
 
     @pedidos_bp.route('/pedidos/<rut>', methods=['GET'])
     def get_pedidos_by_rut(rut):
-        return handle_request(f"pedidos/{rut}", "GET")
+        params = {
+            "desde": request.args.get("desde"),
+            "hasta": request.args.get("hasta")
+        }
+        return handle_request(f"pedidos/{rut}", "GET", params=params)
 
     @pedidos_bp.route('/pedidos/diarios/<rut>', methods=['GET'])
     def get_pedidos_diarios_by_rut(rut):

--- a/mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md
+++ b/mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md
@@ -105,6 +105,10 @@ SECRET_KEY = "flask-secret-key"
 
 **Method**: `GET`
 
+**Query Parameters**:
+- `desde` (optional): Start date for filtering pedidos.
+- `hasta` (optional): End date for filtering pedidos.
+
 **Description**: Bring the complete list of 'pedidos', using User's RUT.
 
 **Response**:

--- a/mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py
+++ b/mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py
@@ -62,7 +62,20 @@ def get_pedidos_diarios():
 # Get all pedidos by rut
 @pedidos_bp.route('/pedidos/<rut>', methods=['GET'])
 def get_pedidos_by_rut(rut):
-    pedidos = list(pedidos_collection.find({"rut": rut}))
+    # Query params
+    fecha_inicio = request.args.get("desde")  # min date
+    fecha_fin = request.args.get("hasta")  # max date
+
+    # MongoDB filter
+    filtro = {"rut": rut}
+    if fecha_inicio or fecha_fin:
+        filtro["fecha_pedido"] = {}
+        if fecha_inicio:
+            filtro["fecha_pedido"]["$gte"] = fecha_inicio
+        if fecha_fin:
+            filtro["fecha_pedido"]["$lte"] = fecha_fin
+
+    pedidos = list(pedidos_collection.find(filtro))
     
     for pedido in pedidos:
         pedido['_id'] = str(pedido['_id'])


### PR DESCRIPTION
This pull request introduces enhancements to the `pedidos` endpoints by adding optional date filters to the requests. The most important changes include updating the `get_pedidos_by_rut` function to accept query parameters, modifying the corresponding route handler to include these parameters, and documenting the new query parameters in the API documentation.

Enhancements to `pedidos` endpoints:

* [`mofulunches-api/api_gateway/blueprints/pedidos_service/pedidos.py`](diffhunk://#diff-6051904615a331fdaee002cf50f48249de351fb05a43b3b0401ded0bbba10d83L45-R49): Updated the `get_pedidos_by_rut` function to accept `desde` and `hasta` query parameters for filtering pedidos by date range.
* [`mofulunches-api/pedidos_service/blueprints/pedidos/pedidos_routes.py`](diffhunk://#diff-6d5e1c345f7a0761473567b1560a7e07989108c7cc9ded0382b7c3ef5a95a27dL65-R78): Modified the `get_pedidos_by_rut` function to construct a MongoDB filter using the `desde` and `hasta` query parameters, enabling date range filtering of pedidos.

Documentation updates:

* [`mofulunches-api/pedidos_service/PEDIDOS_ENDPOINTS.md`](diffhunk://#diff-2b393b2b89d3b53f6d79485c779f59c801d95f4a8c1a2795d68b287ef2aa098aR108-R111): Added documentation for the new `desde` and `hasta` query parameters in the `GET /pedidos/<rut>` endpoint.